### PR TITLE
Delete snippet placeholders when accepting completion

### DIFF
--- a/helix-lsp/src/snippet.rs
+++ b/helix-lsp/src/snippet.rs
@@ -64,6 +64,7 @@ pub fn into_transaction<'a>(
     edit: &lsp_types::TextEdit,
     line_ending: &str,
     offset_encoding: OffsetEncoding,
+    include_placeholer: bool,
 ) -> helix_core::Transaction {
     use helix_core::{smallvec, Range, Selection, Transaction};
     use SnippetElement::*;
@@ -119,10 +120,14 @@ pub fn into_transaction<'a>(
                 // https://doc.rust-lang.org/beta/unstable-book/language-features/box-patterns.html
                 // would make this a bit nicer
                 Text(text) => {
-                    let len_chars = text.chars().count();
-                    tabstops.push((tabstop, Range::new(offset, offset + len_chars + 1)));
-                    offset += len_chars;
-                    insert.push_str(text);
+                    if include_placeholer {
+                        let len_chars = text.chars().count();
+                        tabstops.push((tabstop, Range::new(offset, offset + len_chars + 1)));
+                        offset += len_chars;
+                        insert.push_str(text);
+                    } else {
+                        tabstops.push((tabstop, Range::point(offset)));
+                    }
                 }
                 other => {
                     log::error!(

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -107,6 +107,7 @@ impl Completion {
                 offset_encoding: helix_lsp::OffsetEncoding,
                 start_offset: usize,
                 trigger_offset: usize,
+                include_placeholder: bool,
             ) -> Transaction {
                 use helix_lsp::snippet;
 
@@ -133,6 +134,7 @@ impl Completion {
                                 &edit,
                                 doc.line_ending.as_str(),
                                 offset_encoding,
+                                include_placeholder,
                             ),
                             Err(err) => {
                                 log::error!(
@@ -205,6 +207,7 @@ impl Completion {
                         offset_encoding,
                         start_offset,
                         trigger_offset,
+                        true,
                     );
 
                     // initialize a savepoint
@@ -227,6 +230,7 @@ impl Completion {
                         offset_encoding,
                         start_offset,
                         trigger_offset,
+                        false,
                     );
 
                     doc.apply(&transaction, view.id);


### PR DESCRIPTION
When accepting a snippet completion we automatically delete the placeholders for now as doing so manual is quite cumbersome. In the future we should keep these as a mark + virtual text that is automatically removed once the cursor moves to a placeholder.