### PR TITLE
Fix multiline snippets for completions without offsets

### DIFF
--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -332,9 +332,11 @@ pub mod util {
                     .unwrap()
                     .iter()
                     .map(move |(from, to)| {
+                        // TODO: We can't use range.cursor() here because the text hasn't been updated yet
+                        let cursor = std::cmp::min(range.anchor, range.head);
                         Range::new(
-                            (range.anchor as i128 + *from) as usize,
-                            (range.anchor as i128 + *to) as usize,
+                            (cursor as i128 + *from) as usize,
+                            (cursor as i128 + *to) as usize,
                         )
                     })
             });

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -914,8 +914,8 @@ impl EditorView {
                                 doc.apply(&tx, view.id);
                             }
                             InsertEvent::TriggerCompletion => {
-                                let (_, doc) = current!(cxt.editor);
-                                doc.savepoint();
+                                let (view, doc) = current!(cxt.editor);
+                                doc.savepoint(view);
                             }
                         }
                     }
@@ -958,7 +958,8 @@ impl EditorView {
         }
 
         // Immediately initialize a savepoint
-        doc_mut!(editor).savepoint();
+        let (view, doc) = current!(editor);
+        doc.savepoint(view);
 
         editor.last_completion = None;
         self.last_insert.1.push(InsertEvent::TriggerCompletion);

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -940,8 +940,9 @@ impl Document {
         self.undo_redo_impl(view, false)
     }
 
-    pub fn savepoint(&mut self) {
-        self.savepoint = Some(Transaction::new(self.text()));
+    pub fn savepoint(&mut self, view: &mut View) {
+        self.savepoint =
+            Some(Transaction::new(self.text()).with_selection(self.selection(view.id).clone()));
     }
 
     pub fn restore(&mut self, view: &mut View) {


### PR DESCRIPTION
This fixes an issue reported by @leonqadirie on the main PR ... as well as some more subtle bugs.

1. The previous logic for completions without offset was trimming the prefix from the completion (it was also incorrectly using trim_start_matches instead of strip_prefix). This was messing up offsets for multi-line completions.
2. Fixing issue 1 exposed an issue with savepoint - it was not storing the original selection. This meant that reverting a replacement completion could result in cursor being misplaced (this would happen if placeholder selected was in the middle of a completion). 
3. Fixing issue 2 made an existing bug more obvious - we were incorrectly computing the cursor from a range in generate_transaction_from_snippet. It was resulting in selection being shifted by 1 character if the range was facing backwards.

I think that fixes for issues 1 and 2 are reasonable.
I'm not sure about the fix for issue 3. This investigation also exposed the fact that generate_transaction_from_snippet currently depends on cursor ending up at the end of the completion after the completion transaction is applied (which seems like a reasonable expectation given that completion is triggered at a cursor position, but it also makes the code more fragile). If we don't want to have this dependency generate_transaction_from_snippet should be updated to not rely on selection.clone().map(transaction.changes()).